### PR TITLE
supporting non ssl domains

### DIFF
--- a/lib/bitbucket-file.coffee
+++ b/lib/bitbucket-file.coffee
@@ -165,7 +165,7 @@ class BitbucketFile
 
   # Internal
   bitbucketCloudRepoUrl: (url) ->
-    if url.match /https:\/\/[^\/]+\// # e.g., https://bitbucket.org/foo/bar.git
+    if url.match /https?:\/\/[^\/]+\// # e.g., https://bitbucket.org/foo/bar.git or http://bitbucket.org/foo/bar.git
       url = url.replace(/\.git$/, '')
     else if url.match /^git[^@]*@[^:]+:/    # e.g., git@bitbucket.org:foo/bar.git
       url = url.replace /^git[^@]*@([^:]+):(.+)$/, (match, host, repoPath) ->

--- a/spec/bitbucket-file-spec.coffee
+++ b/spec/bitbucket-file-spec.coffee
@@ -423,6 +423,10 @@ describe "BitbucketFile", ->
       bitbucketFile.gitUrl = -> "https://bitbucket.org/foo/bar.git"
       expect(bitbucketFile.bitbucketRepoUrl()).toBe "https://bitbucket.org/foo/bar"
 
+    it "returns the BitBucket url for an HTTP non SSL remote URL", ->
+      bitbucketFile.gitUrl = -> "http://bitbucket.org/foo/bar.git"
+      expect(bitbucketFile.bitbucketRepoUrl()).toBe "http://bitbucket.org/foo/bar"
+
     it "returns the Bitbucket.org URL for an SSH remote URL", ->
       bitbucketFile.gitUrl = -> "git@bitbucket.org:foo/bar.git"
       expect(bitbucketFile.bitbucketRepoUrl()).toBe "http://bitbucket.org/foo/bar"


### PR DESCRIPTION
This fixes #3 
The regex only anticipates a url with https. This makes that requirement optional. 
